### PR TITLE
Fix #8 too many files open

### DIFF
--- a/dataset/dbengine.py
+++ b/dataset/dbengine.py
@@ -74,6 +74,7 @@ class DBengine:
         if self.verbose:
             print('Preparing to execute %d queries.'%len(queries))
         tic = time.clock()
+        # TODO(python3): Modify pool to context manager (with statement)
         results = self.pool.map(partial(execute_query, conn_args=self.conn_args, verbose=self.verbose), [(idx, q) for idx, q in enumerate(queries)])
         toc = time.clock()
         if self.verbose:
@@ -85,6 +86,7 @@ class DBengine:
         if self.verbose:
             print('Preparing to execute %d queries.'%len(queries))
         tic = time.clock()
+        # TODO(python3): Modify pool to context manager (with statement)
         results = self.pool.map(
             partial(execute_query_w_backup, conn_args=self.conn_args, verbose=self.verbose, timeout=self.timeout),
             [(idx, q) for idx, q in enumerate(queries)])

--- a/repair/featurize/featurizer.py
+++ b/repair/featurize/featurizer.py
@@ -1,5 +1,10 @@
 from abc import ABCMeta, abstractmethod
+import torch.multiprocessing
 from torch.multiprocessing import Pool
+
+# Specify the sharing strategy manually instead of relying on the
+# default one (which is different based on the OS).
+torch.multiprocessing.set_sharing_strategy('file_system')
 
 
 class Featurizer:


### PR DESCRIPTION
* Fixed by specifying the file sharing strategy making it the same strategy on macOS and linux.
* Verified on Ubuntu 16.04 (which used to crash both on a desktop and a laptop) and macOS
* See #8 