### PR TITLE
 Created separate column for init values (1 or more) and current value (singular value, old 'init_value')

### DIFF
--- a/dataset/dataset.py
+++ b/dataset/dataset.py
@@ -289,7 +289,7 @@ class Dataset:
                     attribute,
                     _vid_,
                     current_value,
-                    string_to_array(regexp_replace(domain, \'[{\"\"}]\', \'\', \'gi\'), \'|||\') AS domain
+                    string_to_array(regexp_replace(domain, \'[{{\"\"}}]\', \'\', \'gi\'), \'|||\') AS domain
             FROM {cell_domain}) AS t1,
             {inf_values_idx} AS t2
         WHERE t1._vid_ = t2._vid_

--- a/domain/domain.py
+++ b/domain/domain.py
@@ -217,7 +217,7 @@ class DomainEngine:
             # 3) the current value (best predicted value)
             for attr in self.active_attributes:
                 init_values, current_value, dom = self.get_domain_cell(attr, row)
-                init_values_idx = list(map(dom.index, init_values))
+                init_values_idx = [dom.index(val) for val in init_values]
                 current_value_idx = dom.index(current_value)
                 cid = self.ds.get_cell_id(tid, attr)
                 fixed = 0

--- a/domain/domain.py
+++ b/domain/domain.py
@@ -221,14 +221,12 @@ class DomainEngine:
                 if len(dom) == 1:
                     fixed = 1
                     add_domain = self.get_random_domain(attr, init_values)
-                    # Check if attribute has more than one unique values
-                    if len(add_domain) > 0:
-                        dom.extend(add_domain)
+                    dom.extend(add_domain)
 
                 app.append({"_tid_": tid, "_cid_": cid, "_vid_":vid,
                             "attribute": attr, "attribute_idx": self.ds.attr_to_idx[attr],
                             "domain": '|||'.join(dom), "domain_size": len(dom),
-                            "init_values": '|||'.join(init_values), "init_values_idx": '|||'.join(init_values_idx),
+                            "init_values": '|||'.join(init_values), "init_values_idx": '|||'.join(map(str,init_values_idx)),
                             "current_value": current_value, "current_value_idx": current_value_idx,
                             "fixed": fixed})
                 vid+=1

--- a/evaluate/eval.py
+++ b/evaluate/eval.py
@@ -91,26 +91,46 @@ class EvalEngine:
         return report, report_time, report_list
 
     def compute_total_repairs(self):
-        query = "SELECT count(*) FROM " \
-                "(SELECT _vid_ " \
-                 "FROM %s as t1, %s as t2 " \
-                 "WHERE t1._tid_ = t2._tid_ " \
-                   "AND t1.attribute = t2.attribute " \
-                   "AND t1.init_value != t2.rv_value) AS t"\
-                %(AuxTables.cell_domain.name, AuxTables.inf_values_dom.name)
+        query = """
+        SELECT
+            count(*)
+        FROM
+            (SELECT
+                _vid_
+            FROM
+                {cell_domain} AS t1,
+                {inf_values_dom} as t2
+            WHERE
+                t1._tid_ = t2._tid_
+                AND t1.attribute = t2.attribute
+                AND t1.current_value != t2.rv_value
+            )
+        """.format(cell_domain=AuxTables.cell_domain.name,
+                inf_values_dom=AuxTables.inf_values_dom.name)
         res = self.ds.engine.execute_query(query)
         self.total_repairs = float(res[0][0])
 
     def compute_total_repairs_grdt(self):
-        query = "SELECT count(*) FROM " \
-                "(SELECT _vid_ " \
-                 "FROM %s as t1, %s as t2, %s as t3 " \
-                 "WHERE t1._tid_ = t2._tid_ " \
-                   "AND t1.attribute = t2.attribute " \
-                   "AND t1.init_value != t2.rv_value " \
-                   "AND t1._tid_ = t3._tid_ " \
-                   "AND t1.attribute = t3._attribute_) AS t"\
-                %(AuxTables.cell_domain.name, AuxTables.inf_values_dom.name, self.clean_data.name)
+        query = """
+        SELECT
+            count(*)
+        FROM
+            (SELECT
+                _vid_
+            FROM
+                {cell_domain} AS t1,
+                {inf_values_dom} AS t2,
+                {clean_data} AS t3
+            WHERE
+                t1._tid_ = t2._tid_
+                AND t1.attribute = t2.attribute
+                AND t1.current_value != t2.rv_value
+                AND t1._tid_ = t3._tid_
+                AND t1.attribute = t3._attribute_
+            ) AS t
+        """.format(cell_domain=AuxTables.cell_domain.name,
+                inf_values_dom=AuxTables.inf_values_dom.name,
+                clean_data=self.clean_data.name)
         res = self.ds.engine.execute_query(query)
         self.total_repairs_grdt = float(res[0][0])
 
@@ -139,13 +159,25 @@ class EvalEngine:
         self.total_errors = total_errors
 
     def compute_detected_errors(self):
-        query = "SELECT count(*) FROM " \
-                "(SELECT _vid_ " \
-                "FROM %s as t1, %s as t2, %s as t3 " \
-                "WHERE t1._tid_ = t2._tid_ AND t1._cid_ = t3._cid_ " \
-                "AND t1.attribute = t2._attribute_ " \
-                "AND t1.init_value != t2._value_) AS t" \
-                % (AuxTables.cell_domain.name, self.clean_data.name, AuxTables.dk_cells.name)
+        query = """
+        SELECT
+            count(*)
+        FROM
+            (SELECT
+                _vid_
+            FROM
+                {cell_domain} AS t1,
+                {clean_data} AS t2,
+                {dk_cells} AS t3
+            WHERE
+                t1._tid_ = t2._tid_
+                AND t1._cid_ = t3._cid_
+                AND t1.attribute = t2._attribute_
+                AND t1.current_value != t2._value_
+            ) AS t
+        """.format(cell_domain=AuxTables.cell_domain.name,
+                clean_data=self.clean_data.name,
+                dk_cells=AuxTables.dk_cells.name)
         res = self.ds.engine.execute_query(query)
         self.detected_errors = float(res[0][0])
 

--- a/evaluate/eval.py
+++ b/evaluate/eval.py
@@ -104,7 +104,7 @@ class EvalEngine:
                 t1._tid_ = t2._tid_
                 AND t1.attribute = t2.attribute
                 AND t1.current_value != t2.rv_value
-            )
+            ) AS t
         """.format(cell_domain=AuxTables.cell_domain.name,
                 inf_values_dom=AuxTables.inf_values_dom.name)
         res = self.ds.engine.execute_query(query)

--- a/examples/holoclean_repair_example.py
+++ b/examples/holoclean_repair_example.py
@@ -1,8 +1,8 @@
 import holoclean
 from detect import NullDetector, ViolationDetector
-from repair.featurize import InitFeaturizer
-from repair.featurize import InitAttFeaturizer
-from repair.featurize import InitSimFeaturizer
+from repair.featurize import CurrentFeaturizer
+from repair.featurize import CurrentAttrFeaturizer
+from repair.featurize import CurrentSimFeaturizer
 from repair.featurize import FreqFeaturizer
 from repair.featurize import OccurFeaturizer
 from repair.featurize import ConstraintFeat
@@ -23,7 +23,7 @@ hc.detect_errors(detectors)
 
 # 4. Repair errors utilizing the defined features.
 hc.setup_domain()
-featurizers = [InitAttFeaturizer(learnable=False), InitSimFeaturizer(), FreqFeaturizer(), OccurFeaturizer(), LangModelFeat(), ConstraintFeat()]
+featurizers = [CurrentAttrFeaturizer(learnable=False), CurrentSimFeaturizer(), FreqFeaturizer(), OccurFeaturizer(), LangModelFeat(), ConstraintFeat()]
 hc.repair_errors(featurizers)
 
 # 5. Evaluate the correctness of the results.

--- a/repair/featurize/__init__.py
+++ b/repair/featurize/__init__.py
@@ -1,13 +1,13 @@
 from .featurize import FeaturizedDataset
 from .featurizer import Featurizer
-from .initfeat import InitFeaturizer
-from .initsimfeat import InitSimFeaturizer
-from .freqfeat import FreqFeaturizer
-from .occurfeat import OccurFeaturizer
 from .constraintfeat import ConstraintFeat
+from .currentfeat import CurrentFeaturizer
+from .currentattrfeat import CurrentAttrFeaturizer
+from .currentsimfeat import CurrentSimFeaturizer
+from .freqfeat import FreqFeaturizer
 from .langmodel import LangModelFeat
-from .initattfeat import InitAttFeaturizer
+from .occurfeat import OccurFeaturizer
 from .occurattrfeat import OccurAttrFeaturizer
 
-__all__ = ['FeaturizedDataset', 'Featurizer', 'InitFeaturizer', 'InitSimFeaturizer', 'FreqFeaturizer',
-           'OccurFeaturizer', 'ConstraintFeat', 'LangModelFeat', 'InitAttFeaturizer', 'OccurAttrFeaturizer']
+__all__ = ['FeaturizedDataset', 'Featurizer', 'CurrentFeaturizer', 'CurrentSimFeaturizer', 'FreqFeaturizer',
+           'OccurFeaturizer', 'ConstraintFeat', 'LangModelFeat', 'CurrentAttrFeaturizer', 'OccurAttrFeaturizer']

--- a/repair/featurize/currentattrfeat.py
+++ b/repair/featurize/currentattrfeat.py
@@ -7,23 +7,27 @@ import torch
 def gen_feat_tensor(input, classes, total_attrs):
     vid = int(input[0])
     attr_idx = input[1]
-    init_idx = int(input[2])
+    current_idx = int(input[2])
     tensor = -1.0*torch.ones(1,classes,total_attrs)
-    tensor[0][init_idx][attr_idx] = 1.0
+    tensor[0][current_idx][attr_idx] = 1.0
     return tensor
 
-class InitAttFeaturizer(Featurizer):
+class CurrentAttrFeaturizer(Featurizer):
     def specific_setup(self):
-        self.name = 'InitAttFeaturizer'
+        self.name = 'CurrentAttrFeaturizer'
         self.attr_to_idx = self.ds.attr_to_idx
         self.total_attrs = len(self.ds.attr_to_idx)
 
     def create_tensor(self):
-        query = 'SELECT _vid_, attribute, init_index FROM %s ORDER BY _vid_'%AuxTables.cell_domain.name
+        query = """
+        SELECT
+            _vid_,
+            attribute_idx,
+            current_value_idx
+        FROM {cell_domain}
+        ORDER BY _vid_
+        """.format(cell_domain=AuxTables.cell_domain.name)
         results = self.ds.engine.execute_query(query)
-        map_input = []
-        for res in results:
-            map_input.append((res[0], self.attr_to_idx[res[1]], res[2]))
-        tensors = self.pool.map(partial(gen_feat_tensor, classes=self.classes, total_attrs=self.total_attrs), map_input)
+        tensors = self.pool.map(partial(gen_feat_tensor, classes=self.classes, total_attrs=self.total_attrs), results)
         combined = torch.cat(tensors)
         return combined

--- a/repair/featurize/currentfeat.py
+++ b/repair/featurize/currentfeat.py
@@ -7,18 +7,24 @@ from .featurizer import Featurizer
 
 def gen_feat_tensor(input, classes):
     vid = int(input[0])
-    init_idx = int(input[1])
+    current_idx = int(input[1])
     tensor = -1.0*torch.ones(1,classes,1)
-    tensor[0][init_idx][0] = 1.0
+    tensor[0][current_idx][0] = 1.0
     return tensor
 
 
-class InitFeaturizer(Featurizer):
+class CurrentFeaturizer(Featurizer):
     def specific_setup(self):
-        self.name = 'InitFeaturizer'
+        self.name = 'CurrentFeaturizer'
 
     def create_tensor(self):
-        query = 'SELECT _vid_, init_index FROM %s ORDER BY _vid_'%AuxTables.cell_domain.name
+        query = """
+        SELECT
+            _vid_,
+            current_value_idx
+        FROM {cell_domain}
+        ORDER BY _vid_
+        """.format(cell_domain=AuxTables.cell_domain.name)
         results = self.ds.engine.execute_query(query)
         tensors = self.pool.map(partial(gen_feat_tensor, classes=self.classes), results)
         combined = torch.cat(tensors)

--- a/repair/featurize/currentsimfeat.py
+++ b/repair/featurize/currentsimfeat.py
@@ -9,31 +9,37 @@ from .featurizer import Featurizer
 def gen_feat_tensor(input, classes, total_attrs):
     vid = int(input[0])
     attr_idx = input[1]
-    init_value = input[2]
+    current_value = input[2]
+    domain = input[3].split('|||')
     # TODO: To add more similarity metrics increase the last dimension of tensor.
     tensor = torch.zeros(1, classes, total_attrs)
-    domain = input[2].split('|||')
     for idx, val in enumerate(domain):
-        if val == init_value:
+        if val == current_value:
             sim = -1.0
         else:
-            sim = 2*Levenshtein.ratio(val, init_value) - 1
+            sim = 2*Levenshtein.ratio(val, current_value) - 1
         tensor[0][idx][attr_idx] = sim
     return tensor
 
 
-class InitSimFeaturizer(Featurizer):
+class CurrentSimFeaturizer(Featurizer):
     def specific_setup(self):
-        self.name = 'InitSimFeaturizer'
+        self.name = 'CurrentSimFeaturizer'
         self.attr_to_idx = self.ds.attr_to_idx
         self.total_attrs = len(self.ds.attr_to_idx)
 
     def create_tensor(self):
-        query = 'SELECT _vid_, attribute, init_value, domain FROM %s ORDER BY _vid_'%AuxTables.cell_domain.name
+        query = """
+        SELECT
+            _vid_,
+            attribute_idx,
+            current_value,
+            domain
+        FROM {cell_domain}
+        ORDER BY _vid_
+        """.format(cell_domain=AuxTables.cell_domain.name)
         results = self.ds.engine.execute_query(query)
-        map_input = []
-        for res in results:
-            map_input.append((res[0],self.attr_to_idx[res[1]],res[2]))
-        tensors = self.pool.map(partial(gen_feat_tensor, classes=self.classes, total_attrs=self.total_attrs), map_input)
+        # Map attribute to their attribute indexes
+        tensors = self.pool.map(partial(gen_feat_tensor, classes=self.classes, total_attrs=self.total_attrs), results)
         combined = torch.cat(tensors)
         return combined

--- a/repair/featurize/featurize.py
+++ b/repair/featurize/featurize.py
@@ -6,6 +6,7 @@ from dataset import AuxTables
 
 FeatInfo = namedtuple('FeatInfo', ['name', 'size', 'learnable', 'init_weight'])
 
+
 class FeaturizedDataset:
     def __init__(self, dataset, env, featurizers):
         self.ds = dataset
@@ -36,7 +37,7 @@ class FeaturizedDataset:
         query = """
         SELECT
             _vid_,
-            current_index
+            current_value_idx
         FROM
             {cell_domain} AS t1
         LEFT JOIN

--- a/repair/featurize/featurize.py
+++ b/repair/featurize/featurize.py
@@ -26,16 +26,27 @@ class FeaturizedDataset:
     def generate_weak_labels(self):
         """
         generate_weak_labels returns a tensor where for each VID we have the
-        domain index of the initial value.
+        domain index of the current value.
 
         :return: Torch.Tensor of size (# of variables) X 1 where tensor[i][0]
-            contains the domain index of the initial value for the i-th
+            contains the domain index of the current value for the i-th
             variable/VID.
         """
         logging.debug("Generating weak labels.")
-        query = 'SELECT _vid_, init_index FROM %s AS t1 LEFT JOIN %s AS t2 ' \
-                'ON t1._cid_ = t2._cid_ WHERE t2._cid_ is NULL OR t1.fixed = 1;' % (
-        AuxTables.cell_domain.name, AuxTables.dk_cells.name)
+        query = """
+        SELECT
+            _vid_,
+            current_index
+        FROM
+            {cell_domain} AS t1
+        LEFT JOIN
+            {dk_cells} AS t2
+        ON t1._cid_ = t2._cid_
+        WHERE
+            t2._cid_ is NULL
+            OR t1.fixed = 1
+        """.format(cell_domain=AuxTables.cell_domain.name,
+                dk_cells=AuxTables.dk_cells.name)
         res = self.ds.engine.execute_query(query)
         if len(res) == 0:
             raise Exception("No weak labels available. Reduce pruning threshold.")
@@ -82,10 +93,10 @@ class FeaturizedDataset:
         get_training_data returns X_train, y_train, and mask_train
         where each row of each tensor is a variable/VID and
         y_train are weak labels for each variable i.e. they are
-        set as the initial values.
+        set as the current value.
 
-        This assumes that we have a larger proportion of correct initial values
-        and only a small amount of incorrect initial values which allow us
+        This assumes that we have a larger proportion of correct current values
+        and only a small amount of incorrect current values which allow us
         to train to convergence.
         """
         train_idx = (self.weak_labels != -1).nonzero()[:,0]

--- a/repair/featurize/occurfeat.py
+++ b/repair/featurize/occurfeat.py
@@ -23,7 +23,7 @@ class OccurFeaturizer(Featurizer):
         """
         Memoize single (frequency of attribute-value) and
         pairwise stats (frequency of attr1-value1-attr2-value2)
-        from Dataset.
+        for the current values from loaded dataset.
 
         self.single_stats is a dict { attribute -> { value -> count } }.
         self.pair_stats is a dict { attr1 -> { attr2 -> { val1 -> {val2 -> co-occur frequency } } } }.
@@ -38,12 +38,12 @@ class OccurFeaturizer(Featurizer):
     def create_tensor(self):
         """
         For each unique VID (cell) returns the co-occurrence probability between
-        each possible domain value for this VID and the initial/raw values for the
+        each possible domain value for this VID and the current value for the
         corresponding entity/tuple of this cell.
 
         :return: Torch.Tensor of shape (# of VIDs) X (max domain) X (# of attributes)
             where tensor[i][j][k] contains the co-occur probability between the j-th domain value
-            of the i-th random variable (VID) and the initial/raw value of the k-th
+            of the i-th random variable (VID) and the current value of the k-th
             attribute for the corresponding entity.
         """
         # Iterate over tuples in domain

--- a/tests/test_holoclean_repair.py
+++ b/tests/test_holoclean_repair.py
@@ -2,9 +2,9 @@ import unittest
 
 import holoclean
 from detect import NullDetector, ViolationDetector
-from repair.featurize import InitFeaturizer
-from repair.featurize import InitAttFeaturizer
-from repair.featurize import InitSimFeaturizer
+from repair.featurize import CurrentFeaturizer
+from repair.featurize import CurrentAttrFeaturizer
+from repair.featurize import CurrentSimFeaturizer
 from repair.featurize import FreqFeaturizer
 from repair.featurize import OccurFeaturizer
 from repair.featurize import ConstraintFeat
@@ -27,7 +27,7 @@ class TestHolocleanRepair(unittest.TestCase):
 
         # 4. Repair errors utilizing the defined features.
         hc.setup_domain()
-        featurizers = [InitAttFeaturizer(), InitSimFeaturizer(), FreqFeaturizer(), OccurFeaturizer(), LangModelFeat(), ConstraintFeat()]
+        featurizers = [CurrentAttrFeaturizer(), CurrentSimFeaturizer(), FreqFeaturizer(), OccurFeaturizer(), LangModelFeat(), ConstraintFeat()]
         hc.repair_errors(featurizers)
 
         # 5. Evaluate the correctness of the results.


### PR DESCRIPTION
This will allow us to specify multiple initial values for a given cell that we could use in a special `MultiInitFeaturizer` or `MultiOccurFeaturizer`.

The old `init_value` is now `current_value` (all featurizers have been changed to reference `current_value` and renamed from e.g. `InitFeaturizer` to `CurrentFeaturizer`).

Also fixed a bug in `InitSimFeaturizer` where it wasn't computing the similarity metrics correctly between the `init_value` and values in the domain.