### PR TITLE
Fix NullDetector and regression with status (dev branch)

### DIFF
--- a/detect/nulldetector.py
+++ b/detect/nulldetector.py
@@ -22,7 +22,7 @@ class NullDetector(Detector):
         attributes = self.ds.get_attributes()
         errors = []
         for attr in attributes:
-            tmp_df = self.df[self.df[attr].isnull()]['_tid_'].to_frame()
+            tmp_df = self.df[self.df[attr] == '_nan_']['_tid_'].to_frame()
             tmp_df.insert(1, "attribute", attr)
             errors.append(tmp_df)
         errors_df = pd.concat(errors, ignore_index=True)

--- a/detect/nulldetector.py
+++ b/detect/nulldetector.py
@@ -22,6 +22,9 @@ class NullDetector(Detector):
         attributes = self.ds.get_attributes()
         errors = []
         for attr in attributes:
+            # do not add attributes in which all values are null
+            if (self.df[attr] == '_nan_').all():
+                continue
             tmp_df = self.df[self.df[attr] == '_nan_']['_tid_'].to_frame()
             tmp_df.insert(1, "attribute", attr)
             errors.append(tmp_df)

--- a/repair/repair.py
+++ b/repair/repair.py
@@ -72,4 +72,4 @@ class RepairEngine:
         report = self.repair_model.get_featurizer_weights(self.feat_dataset.featurizer_info, self.feat_dataset.debugging)
         toc = time.clock()
         report_time = toc - tic
-        return status, report_time
+        return report, report_time


### PR DESCRIPTION
Note that we convert all NULL values in `Table.load_data` into `'_nan_'`, so we should really be checking for the string.

The master branch uses `str.match` which actually does a regex match, which can be comparatively slower.