### PR TITLE
Memoize get_corr_attributes and a few style changes.

### DIFF
--- a/dataset/dataset.py
+++ b/dataset/dataset.py
@@ -214,7 +214,11 @@ class Dataset:
                 <count>: frequency (# of entities) where attr1=val1 AND attr2=val2
         """
         if not self.stats_ready:
+            logging.debug('computing frequency and co-occurrence statistics from raw data...')
+            tic = time.clock()
             self.collect_stats()
+            logging.debug('DONE computing statistics in %.2fs', time.clock() - tic)
+
         stats = (self.total_tuples, self.single_attr_stats, self.pair_attr_stats)
         self.stats_ready = True
         return stats

--- a/dataset/dbengine.py
+++ b/dataset/dbengine.py
@@ -7,9 +7,9 @@ import time
 import psycopg2
 import sqlalchemy as sql
 
-index_template = Template('CREATE INDEX $idx_title ON $table ($attr)')
-drop_table_template = Template('DROP TABLE IF EXISTS $tab_name')
-create_table_template = Template('CREATE TABLE $tab_name AS ($stmt)')
+index_template = Template('CREATE INDEX $idx_title ON "$table" ($attrs)')
+drop_table_template = Template('DROP TABLE IF EXISTS "$table"')
+create_table_template = Template('CREATE TABLE "$table" AS ($stmt)')
 
 
 class DBengine:
@@ -56,8 +56,8 @@ class DBengine:
 
     def create_db_table_from_query(self, name, query):
         tic = time.clock()
-        drop = drop_table_template.substitute(tab_name=name)
-        create = create_table_template.substitute(tab_name=name, stmt=query)
+        drop = drop_table_template.substitute(table=name)
+        create = create_table_template.substitute(table=name, stmt=query)
         conn = self.engine.connect()
         dropped = conn.execute(drop)
         created = conn.execute(create)
@@ -79,7 +79,7 @@ class DBengine:
         # We need to quote each attribute since Postgres auto-downcases unquoted column references
 
         quoted_attrs = map(lambda attr: '"{}"'.format(attr), attr_list)
-        stmt = index_template.substitute(idx_title=name, table=table, attr=','.join(quoted_attrs))
+        stmt = index_template.substitute(idx_title=name, table=table, attrs=','.join(quoted_attrs))
         tic = time.clock()
         conn = self.engine.connect()
         result = conn.execute(stmt)

--- a/detect/violationdetector.py
+++ b/detect/violationdetector.py
@@ -4,8 +4,8 @@ import pandas as pd
 
 from .detector import Detector
 
-unary_template = Template('SELECT t1._tid_ FROM $table as t1 WHERE $cond')
-multi_template = Template('SELECT t1._tid_ FROM $table as t1 WHERE $cond1 $c EXISTS (SELECT t2._tid_ FROM $table as t2 WHERE $cond2)')
+unary_template = Template('SELECT t1._tid_ FROM "$table" as t1 WHERE $cond')
+multi_template = Template('SELECT t1._tid_ FROM "$table" as t1 WHERE $cond1 $c EXISTS (SELECT t2._tid_ FROM "$table" as t2 WHERE $cond2)')
 
 
 class ViolationDetector(Detector):

--- a/domain/estimators/recurrent_logistic.py
+++ b/domain/estimators/recurrent_logistic.py
@@ -3,6 +3,7 @@ import copy
 import logging
 
 import pandas as pd
+import time
 import torch
 from torch.utils.data import TensorDataset, DataLoader
 from tqdm import tqdm
@@ -40,7 +41,7 @@ class RecurrentLogistic(Estimator, torch.nn.Module):
         self.cur_df = self.ds.get_raw_data().copy()
 
         # Generate featurizers for this model.
-        self._update_featurizers()
+        self._update_featurizers(reuse_stats=True)
 
         # Make a copy of the initial featurizers for prediction/test set
         # i.e., we want to use our original co-occurrence statistics.
@@ -53,15 +54,21 @@ class RecurrentLogistic(Estimator, torch.nn.Module):
         self._loss = torch.nn.BCELoss()
         self._optimizer = torch.optim.Adam(self.parameters())
 
-    def _update_featurizers(self):
+    def _update_featurizers(self, reuse_stats=False):
         """
         Reinitialize featurizers that depend on updated current values.
+
+        :param reuse_stats: (bool) reuses frequency and co-occurrence statistics from
+            raw Dataset instead of re-computing.
         """
 
         # Featurizers used for training.
-        self.train_featurizers = [
-            CooccurAttrFeaturizer(self.cur_df, self.attrs),
-        ]
+        freq, cooccur_freq = None, None
+        if reuse_stats:
+            _, freq, cooccur_freq = self.ds.get_statistics()
+
+        self.train_featurizers = [CooccurAttrFeaturizer(self.cur_df,
+                    self.attrs, freq=freq, cooccur_freq=cooccur_freq)]
         # Initialize featurizers.
         [feat.setup() for feat in self.train_featurizers]
 
@@ -76,7 +83,7 @@ class RecurrentLogistic(Estimator, torch.nn.Module):
         self._X = torch.zeros(self.n_samples, self.num_features)
         self._Y = torch.zeros(self.n_samples)
 
-        logging.info('RecurrentLogistic: featurizing training data')
+        logging.debug('RecurrentLogistic: featurizing training data...')
 
         sample_idx = 0
         domain_idx_df = []
@@ -102,7 +109,14 @@ class RecurrentLogistic(Estimator, torch.nn.Module):
 
                 sample_idx += len(domain_vals)
 
-        # Map index (along first dimension) in self._X and self._Y to domain values.
+        """
+        Map index (along first dimension) in self._X and self._Y to domain
+        values, that is the dataframe has columns:
+            (Index)     |    _tid_      |   attr    |   val
+
+        where the (Index)-th row of self._X/self._Y corresponds to the
+        possible/domain value with _tid_, attr, and val.
+        """
         self._domain_idx_df = pd.DataFrame(domain_idx_df)
 
     def _gen_train_tensor(self, row, attr, values):
@@ -172,11 +186,11 @@ class RecurrentLogistic(Estimator, torch.nn.Module):
             self._update_training_data()
             torch_ds = TensorDataset(self._X, self._Y)
 
-            logging.info("RecurrentLogistic: training, recur iteration: %d", recur_idx)
+            logging.debug("RecurrentLogistic: training, recur iteration: %d", recur_idx)
 
             # Main training loop.
             for epoch_idx in range(1, num_epochs+1):
-                logging.info("RecurrentLogistic: epoch %d", epoch_idx)
+                logging.debug("RecurrentLogistic: epoch %d", epoch_idx)
                 batch_cnt = 0
                 for batch_X, batch_Y in tqdm(DataLoader(torch_ds, batch_size=batch_size)):
                     batch_pred = self.forward(batch_X)
@@ -186,7 +200,7 @@ class RecurrentLogistic(Estimator, torch.nn.Module):
                     batch_loss.backward()
                     self._optimizer.step()
                     batch_cnt += 1
-                logging.info('RecurrentLogistic: average batch loss is %.3f', sum(batch_losses[-1 * batch_cnt:]) / batch_cnt)
+                logging.debug('RecurrentLogistic: average batch loss is %f', sum(batch_losses[-1 * batch_cnt:]) / batch_cnt)
                 # TODO(richardwu): update cur_df with predictions
 
         return batch_losses
@@ -208,23 +222,26 @@ class RecurrentLogistic(Estimator, torch.nn.Module):
         :param raw_records_by_tid: (dict) maps TID to its corresponding row (record) in the raw data
         :param cell_domain_rows: (list[pd.record]) list of records from the cell domain DF
         """
-        logging.info('RecurrentLogistic: constructing batch feature tensor for %d cells...', cell_domain_rows.shape[0])
+        logging.debug('RecurrentLogistic: constructing feature tensor for %d cells...', cell_domain_rows.shape[0])
         X_tensors = []
         for row in tqdm(cell_domain_rows):
             X_tensors.append(self._gen_test_tensor(raw_records_by_tid[row['_tid_']],
                                                    row['attribute'], row['domain'].split('|||')))
+        logging.debug('RecurrentLogistic: DONE featurization.')
         pred_X = torch.cat(X_tensors, dim=0)
-        logging.info('RecurrentLogistic: predicting posterior probabilities for batch feature tensor...')
+        logging.debug('RecurrentLogistic: predicting posterior probabilities for tensors...')
         pred_Y = self.forward(pred_X)
+        logging.debug('RecurrentLogistic: DONE prediction.')
 
         cur_idx = 0
-        logging.info('RecurrentLogistic: segmenting predictions by cell...')
+        logging.debug('RecurrentLogistic: segmenting predictions by cell...')
         probs_by_row = []
-        for row in cell_domain_rows:
+        for row in tqdm(cell_domain_rows):
             # Create list of (value, proba) for each cell.
             probs_by_row.append(list(zip(row['domain'].split('|||'),
                 map(float, pred_Y[cur_idx:cur_idx+row['domain_size']]))))
             cur_idx += row['domain_size']
+        logging.debug('RecurrentLogistic: DONE segmentation.')
         return probs_by_row
 
 
@@ -254,34 +271,54 @@ class Featurizer:
 
 
 class CooccurFeaturizer(Featurizer):
+    name = 'CooccurFeaturizer'
+
     """
     CooccurFeaturizer is DEPRECATED. Please use CooccurAttrFeaturizer.
     """
-    def __init__(self, data_df, attrs):
+    def __init__(self, data_df, attrs, freq=None, cooccur_freq=None):
         """
         :param data_df: (pandas.DataFrame) contains the data to compute co-occurrence features for.
         :param attrs: attributes in columns of :param data_df: to compute feautres for.
+        :param freq: (dict { attr: { val: count } } }) if not None, uses these
+            frequency statistics instead of computing it from data_df.
+        :param cooccur_freq: (dict { attr1: { attr2: { val1: { val2: count } } } })
+            if not None, uses these co-occurrence statistics instead of
+            computing it from data_df.
         """
         self.data_df = data_df
         self.attrs = attrs
+        self.freq = freq
+        self.cooccur_freq = cooccur_freq
 
     def num_features(self):
         return len(self.attrs)
 
     def setup(self):
-        # Frequencies of values per each attribute
-        self.freq = {}
-        for attr in self.attrs:
-            self.freq[attr] = self._get_freq(attr)
+        logging.debug("%s: setting up co-occurrence statistics...", self.name)
+        tic = time.clock()
 
-        # Co-occurrence counts per each attribute pair (and value pair)
-        self.cooccur_freq = {}
-        for attr1 in self.attrs:
-            self.cooccur_freq[attr1] = {}
-            for attr2 in self.attrs:
-                if attr1 == attr2:
-                    continue
-                self.cooccur_freq[attr1][attr2] = self._get_cooccur_freq(attr1, attr2)
+        if self.freq is None:
+            logging.debug("%s: re-using frequency statistics passed in")
+        else:
+            # Frequencies of values per each attribute
+            self.freq = {}
+            for attr in self.attrs:
+                self.freq[attr] = self._get_freq(attr)
+
+        if self.cooccur_freq is None:
+            logging.debug("%s: re-using co-occurrence statistics passed in")
+        else:
+            # Co-occurrence counts per each attribute pair (and value pair)
+            self.cooccur_freq = {}
+            for attr1 in self.attrs:
+                self.cooccur_freq[attr1] = {}
+                for attr2 in self.attrs:
+                    if attr1 == attr2:
+                        continue
+                    self.cooccur_freq[attr1][attr2] = self._get_cooccur_freq(attr1, attr2)
+
+        logging.debug("%s: co-occurrence statistics computed in %.2fs", self.name, time.clock() - tic)
 
     def create_tensor(self, row, attr, values):
         """
@@ -334,17 +371,25 @@ class CooccurFeaturizer(Featurizer):
 
 
 class CooccurAttrFeaturizer(CooccurFeaturizer):
+    name = 'CooccurAttrFeaturizer'
+
     """
     CooccurAttrFeaturizer is like CooccurFeaturizer but breaks down each co-occur
     feature on a pairwise attr1 X attr2 basis, instead of one co-occur feature
     per attribute.
     """
-    def __init__(self, data_df, attrs):
+    def __init__(self, data_df, attrs, freq=None, cooccur_freq=None):
         """
         :param data_df: (pandas.DataFrame) contains the data to compute co-occurrence features for.
         :param attrs: attributes in columns of :param data_df: to compute feautres for.
+        :param freq: (dict { attr: { val: count } } }) if not None, uses these
+            frequency statistics instead of computing it from data_df.
+        :param cooccur_freq: (dict { attr1: { attr2: { val1: { val2: count } } } })
+            if not None, uses these co-occurrence statistics instead of
+            computing it from data_df.
         """
-        super(CooccurAttrFeaturizer, self).__init__(data_df, attrs)
+        super(CooccurAttrFeaturizer, self).__init__(data_df, attrs,
+                freq=freq, cooccur_freq=cooccur_freq)
         self.attr_to_idx = {attr: idx for idx, attr in enumerate(self.attrs)}
         self.n_attrs = len(self.attrs)
 

--- a/evaluate/eval.py
+++ b/evaluate/eval.py
@@ -9,7 +9,7 @@ from dataset import AuxTables
 from dataset.table import Table, Source
 
 errors_template = Template('SELECT count(*) ' \
-                           'FROM  $init_table as t1, $grdt_table as t2 ' \
+                           'FROM  "$init_table" as t1, "$grdt_table" as t2 ' \
                            'WHERE t1._tid_ = t2._tid_ ' \
                            '  AND t2._attribute_ = \'$attr\' ' \
                            '  AND t1."$attr" != t2._value_')
@@ -26,7 +26,7 @@ truth value.
 """
 correct_repairs_template = Template('SELECT COUNT(*) FROM '
                                     '  (SELECT t2._tid_, t2._attribute_, t2._value_ '
-                                    '     FROM $init_table as t1, $grdt_table as t2 '
+                                    '     FROM "$init_table" as t1, "$grdt_table" as t2 '
                                     '    WHERE t1._tid_ = t2._tid_ '
                                     '      AND t2._attribute_ = \'$attr\' '
                                     '      AND t1."$attr" != t2._value_ ) as errors, $inf_dom as repairs '

--- a/repair/featurize/constraintfeat.py
+++ b/repair/featurize/constraintfeat.py
@@ -13,7 +13,7 @@ from dcparser.constraint import is_symmetric
 # one relation's (e.g. t1) attribute on one side and a fixed constant
 # value on the other side of the comparison.
 unary_template = Template('SELECT _vid_, val_id, count(*) violations '
-                          'FROM   $init_table as t1, $pos_values as t2 '
+                          'FROM   "$init_table" as t1, $pos_values as t2 '
                           'WHERE  t1._tid_ = t2._tid_ '
                           '  AND t2.attribute = \'$rv_attr\' '
                           '  AND  $orig_predicates '
@@ -24,7 +24,7 @@ unary_template = Template('SELECT _vid_, val_id, count(*) violations '
 # used for detecting violations in pos_values have a reference to both
 # relations (t1, t2) i.e. no constant value in predicate.
 binary_template = Template('SELECT _vid_, val_id, count(*) violations '
-                           'FROM   $init_table as t1, $init_table as t2, $pos_values as t3 '
+                           'FROM   "$init_table" as t1, "$init_table" as t2, $pos_values as t3 '
                            'WHERE  t1._tid_ != t2._tid_ '
                            '  AND $join_rel._tid_ = t3._tid_ '
                            '  AND t3.attribute = \'$rv_attr\' '
@@ -36,11 +36,11 @@ binary_template = Template('SELECT _vid_, val_id, count(*) violations '
 # binary_template takes too long to query. Instead of counting the # of violations
 # this returns simply a 0-1 indicator if the possible value violates the constraint.
 ex_binary_template = Template('SELECT _vid_, val_id, 1 violations '
-                              'FROM   $init_table as $join_rel, $pos_values as t3 '
+                              'FROM   "$init_table" as $join_rel, $pos_values as t3 '
                               'WHERE  $join_rel._tid_ = t3._tid_ '
                               '  AND t3.attribute = \'$rv_attr\' '
                               '  AND EXISTS (SELECT $other_rel._tid_ '
-                              '              FROM $init_table AS $other_rel '
+                              '              FROM "$init_table" AS $other_rel '
                               '              WHERE $join_rel._tid_ != $other_rel._tid_ '
                               '                AND $orig_predicates '
                               '                AND t3.rv_val $operation $rv_val)')


### PR DESCRIPTION
Memoizing get_corr_attributes reduces runtime by about ~20%.

Before:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000  518.609  518.609 holoclean_repair_example.py:1(<module>)
    97684    1.449    0.000   84.456    0.001 domain.py:150(get_corr_attributes)
```

After:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000  446.478  446.478 holoclean_repair_example.py:1(<module>)
    97684    0.035    0.000    0.037    0.000 domain.py:151(get_corr_attributes)
```

