### PR TITLE
Fixed get_infer_data to always return DK cells when infer_labeled=False.

### DIFF
--- a/domain/domain.py
+++ b/domain/domain.py
@@ -252,6 +252,10 @@ class DomainEngine:
         domain_df = pd.DataFrame(data=cells)
         logging.debug('DONE generating initial set of domain values in %.2f', time.clock() - tic)
 
+        # Skip estimator model.
+        if not self.env['estimator_enabled']:
+            return domain_df
+
         # Run pruned domain values from correlated attributes above through
         # posterior model for a naive probability estimation.
         logging.debug('training posterior model for estimating domain value probabilities...')

--- a/holoclean.py
+++ b/holoclean.py
@@ -19,20 +19,20 @@ arguments = [
          'default': 'holocleanuser',
          'type': str,
          'help': 'User for DB used to persist state.'}),
-    (('-p', '--password', '--pass'),
-        {'metavar': 'PASSWORD',
+    (('-p', '--db-pwd', '--pass'),
+        {'metavar': 'DB_PWD',
          'dest': 'db_pwd',
          'default': 'abcd1234',
          'type': str,
          'help': 'Password for DB used to persist state.'}),
-    (('-h', '--host'),
-        {'metavar': 'HOST',
+    (('-h', '--db-host'),
+        {'metavar': 'DB_HOST',
          'dest': 'db_host',
          'default': 'localhost',
          'type': str,
          'help': 'Host for DB used to persist state.'}),
-    (('-d', '--database'),
-        {'metavar': 'DATABASE',
+    (('-d', '--db_name'),
+        {'metavar': 'DB_NAME',
          'dest': 'db_name',
          'default': 'holo',
          'type': str,
@@ -121,6 +121,12 @@ arguments = [
       'default': 0.1,
       'type': float,
       'help': 'Correlation threshold (absolute) when selecting correlated attributes for domain pruning.'}),
+    (('-wlt', '--estimator-enabled'),
+     {'metavar': 'ESTIMATOR_ENABLED',
+      'dest': 'estimator_enabled',
+      'default': True,
+      'type': bool,
+      'help': 'Enables the posterior estimator for weak labelling and domain generation.'}),
 ]
 
 # Flags for Holoclean mode
@@ -207,6 +213,17 @@ class Session:
         :param env: Holoclean environment
         :param name: Name for the Holoclean session
         """
+        # use DEBUG logging level if verbose enabled
+        root_logger = logging.getLogger()
+        gensim_logger = logging.getLogger('gensim')
+        root_level, gensim_level = logging.INFO, logging.WARNING
+        if env['verbose']:
+            root_level, gensim_level = logging.DEBUG, logging.DEBUG
+        root_logger.setLevel(root_level)
+        gensim_logger.setLevel(gensim_level)
+
+        logging.info('initiating session with parameters: %s', env)
+
         # Initialize members
         self.name = name
         self.env = env
@@ -217,14 +234,6 @@ class Session:
         self.repair_engine = RepairEngine(env, self.ds)
         self.eval_engine = EvalEngine(env, self.ds)
 
-        # use DEBUG logging level if verbose enabled
-        root_logger = logging.getLogger()
-        gensim_logger = logging.getLogger('gensim')
-        root_level, gensim_level = logging.INFO, logging.WARNING
-        if self.env['verbose']:
-            root_level, gensim_level = logging.DEBUG, logging.DEBUG
-        root_logger.setLevel(root_level)
-        gensim_logger.setLevel(gensim_level)
 
     def load_data(self, name, fpath, na_values=None, entity_col=None, src_col=None):
         """

--- a/holoclean.py
+++ b/holoclean.py
@@ -9,6 +9,10 @@ from repair import RepairEngine
 from evaluate import EvalEngine
 
 logging.basicConfig(format="%(asctime)s - [%(levelname)5s] - %(message)s", datefmt='%H:%M:%S')
+root_logger = logging.getLogger()
+gensim_logger = logging.getLogger('gensim')
+root_logger.setLevel(logging.INFO)
+gensim_logger.setLevel(logging.WARNING)
 
 
 # Arguments for HoloClean
@@ -214,13 +218,9 @@ class Session:
         :param name: Name for the Holoclean session
         """
         # use DEBUG logging level if verbose enabled
-        root_logger = logging.getLogger()
-        gensim_logger = logging.getLogger('gensim')
-        root_level, gensim_level = logging.INFO, logging.WARNING
         if env['verbose']:
-            root_level, gensim_level = logging.DEBUG, logging.DEBUG
-        root_logger.setLevel(root_level)
-        gensim_logger.setLevel(gensim_level)
+            root_logger.setLevel(logging.DEBUG)
+            gensim_logger.setLevel(logging.DEBUG)
 
         logging.info('initiating session with parameters: %s', env)
 


### PR DESCRIPTION
Also renamed parameter names for better consistency and added `estimator_enabled` parameter which disables the weak labelling pathway.

## Changes to `get_infer_data`

When infer_labeled = True, fixing_domain_gen performed inference on ALL cells (clean and DK). This meant that un-detected errors (clean cells that had errors) were also being repaired. This overestimated the # of correct/total repair and thus it is not recommend to set infer_labeled = True when performing experiments.

When infer_labeled = False, fixing_domain_gen only inferred on non-weak labelled cells. If during weak labelling a DK cell was weak labelled, it would not be inferred. This is fixed in https://github.com/HoloClean/holoclean/pull/56 so all DK cells are inferred regardless of their labelling.