### PR TITLE
Remove NULLs from domain: always predict a non-NULL value.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_script:
   - psql -U postgres -c 'create database holo;'
   - psql -U postgres -c 'CREATE USER holocleanuser;'
   - psql -U postgres -c "ALTER USER holocleanuser WITH PASSWORD 'abcd1234';"
+  - psql -U postgres -c 'ALTER USER holocleanuser WITH SUPERUSER;'
   - psql -U postgres -c 'GRANT ALL PRIVILEGES ON DATABASE holo TO holocleanuser;'
   - psql -U postgres -d holo -c 'ALTER SCHEMA public OWNER TO holocleanuser;'
 

--- a/dataset/dataset.py
+++ b/dataset/dataset.py
@@ -209,6 +209,12 @@ class Dataset:
                 <val1>: all values of <attr1>
                 <val2>: values of <attr2> that appear at least once with <val1>.
                 <count>: frequency (# of entities) where attr1=val1 AND attr2=val2
+
+        NB: neither single_attr_stats nor pair_attr_stats contain frequencies
+            for values that are NULL (NULL_REPR). One would need to explicitly
+            check if the value is NULL before lookup.
+
+            Also, values that only co-occur with NULLs will NOT be in pair_attr_stats.
         """
         if not self.stats_ready:
             logging.debug('computing frequency and co-occurrence statistics from raw data...')
@@ -260,7 +266,7 @@ class Dataset:
             <first_val>: all possible values for first_attr
             <second_val>: all values for second_attr that appear at least once with <first_val>
             <count>: frequency (# of entities) where first_attr=<first_val> AND second_attr=<second_val>
-        Filters out NULL values so no entries in the dictionary would have nulls.
+        Filters out NULL values so no entries in the dictionary would have NULLs.
         """
         data_df = self.get_raw_data()
         tmp_df = data_df[[first_attr, second_attr]]\

--- a/dataset/dataset.py
+++ b/dataset/dataset.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 from .dbengine import DBengine
 from .table import Table, Source
-from utils import dictify_df
+from utils import dictify_df, NULL_REPR
 
 
 class AuxTables(Enum):
@@ -100,8 +100,8 @@ class Dataset:
                 # use entity IDs as _tid_'s directly
                 df.rename({entity_col: '_tid_'}, axis='columns', inplace=True)
 
-            # Use '_nan_' to represent NULL values
-            df.fillna('_nan_', inplace=True)
+            # Use NULL_REPR to represent NULL values
+            df.fillna(NULL_REPR, inplace=True)
 
             logging.info("Loaded %d rows with %d cells", self.raw_data.df.shape[0], self.raw_data.df.shape[0] * self.raw_data.df.shape[1])
 
@@ -242,7 +242,7 @@ class Dataset:
             self.pair_attr_stats[cond_attr] = {}
             for trg_attr in self.get_attributes():
                 if trg_attr != cond_attr:
-                    self.pair_attr_stats[cond_attr][trg_attr] = self.get_stats_pair(cond_attr,trg_attr)
+                    self.pair_attr_stats[cond_attr][trg_attr] = self.get_stats_pair(cond_attr, trg_attr)
 
     def get_stats_single(self, attr):
         """
@@ -251,7 +251,8 @@ class Dataset:
         """
         # need to decode values into unicode strings since we do lookups via
         # unicode strings from Postgres
-        return self.get_raw_data()[[attr]].groupby([attr]).size().to_dict()
+        data_df = self.get_raw_data()
+        return data_df[[attr]].loc[data_df[attr] != NULL_REPR].groupby([attr]).size().to_dict()
 
     def get_stats_pair(self, first_attr, second_attr):
         """
@@ -259,8 +260,14 @@ class Dataset:
             <first_val>: all possible values for first_attr
             <second_val>: all values for second_attr that appear at least once with <first_val>
             <count>: frequency (# of entities) where first_attr=<first_val> AND second_attr=<second_val>
+        Filters out NULL values so no entries in the dictionary would have nulls.
         """
-        tmp_df = self.get_raw_data()[[first_attr, second_attr]].groupby([first_attr, second_attr]).size().reset_index(name="count")
+        data_df = self.get_raw_data()
+        tmp_df = data_df[[first_attr, second_attr]]\
+            .loc[(data_df[first_attr] != NULL_REPR) & (data_df[second_attr] != NULL_REPR)]\
+            .groupby([first_attr, second_attr])\
+            .size()\
+            .reset_index(name="count")
         return dictify_df(tmp_df)
 
     def get_domain_info(self):

--- a/detect/nulldetector.py
+++ b/detect/nulldetector.py
@@ -1,6 +1,7 @@
 import pandas as pd
 
 from .detector import Detector
+from utils import NULL_REPR
 
 
 class NullDetector(Detector):
@@ -28,7 +29,10 @@ class NullDetector(Detector):
         attributes = self.ds.get_attributes()
         errors = []
         for attr in attributes:
-            tmp_df = self.df[self.df[attr] == '_nan_']['_tid_'].to_frame()
+            # do not add attributes in which all values are null
+            if (self.df[attr] == NULL_REPR).all():
+                continue
+            tmp_df = self.df[self.df[attr] == NULL_REPR]['_tid_'].to_frame()
             tmp_df.insert(1, "attribute", attr)
             errors.append(tmp_df)
         errors_df = pd.concat(errors, ignore_index=True)

--- a/detect/nulldetector.py
+++ b/detect/nulldetector.py
@@ -29,9 +29,6 @@ class NullDetector(Detector):
         attributes = self.ds.get_attributes()
         errors = []
         for attr in attributes:
-            # do not add attributes in which all values are null
-            if (self.df[attr] == NULL_REPR).all():
-                continue
             tmp_df = self.df[self.df[attr] == NULL_REPR]['_tid_'].to_frame()
             tmp_df.insert(1, "attribute", attr)
             errors.append(tmp_df)

--- a/domain/domain.py
+++ b/domain/domain.py
@@ -251,6 +251,12 @@ class DomainEngine:
                 cell_status = CellStatus.NOT_SET.value
 
                 if len(dom) <= 1:
+                    # Initial  value is NULL and we cannot come up with
+                    # a domain; a random domain probably won't help us so
+                    # completely ignore this cell and continue.
+                    if init_value == NULL_REPR:
+                        continue
+
                     # Not enough domain values, we need to get some random
                     # values (other than 'init_value') for training. However,
                     # this might still get us zero domain values.

--- a/domain/estimator.py
+++ b/domain/estimator.py
@@ -34,13 +34,9 @@ class Estimator:
         raise NotImplementedError
 
     @abstractmethod
-    def predict_pp_batch(self, raw_records_by_tid, cell_domain_rows):
+    def predict_pp_batch(self):
         """
         predict_pp_batch is like predict_pp but with a batch of cells.
-
-        :param raw_records_by_tid: (dict) maps TID to its corresponding row (record) in the raw data
-        :param cell_domain_rows: (list[pd.record]) list of records from the cell domain DF. Each
-            record should include the field '_tid_', 'attribute', and 'domain'
 
         :return: iterator of iterator of tuples (value, proba) (one iterator per cell/row in cell_domain_rows)
         """

--- a/domain/estimators/logistic.py
+++ b/domain/estimators/logistic.py
@@ -1,16 +1,14 @@
 from abc import ABCMeta, abstractmethod
 import logging
 
-import pandas as pd
 import time
 import torch
-import torch.nn.functional as F
 from torch.optim import Adam, SGD
 from torch.utils.data import TensorDataset, DataLoader
 from tqdm import tqdm
 
 from ..estimator import Estimator
-from utils import dictify_df
+from utils import NULL_REPR, NA_COOCCUR_FV
 
 
 class Logistic(Estimator, torch.nn.Module):
@@ -21,7 +19,7 @@ class Logistic(Estimator, torch.nn.Module):
     of the other initial values such as co-occurrence.
     """
 
-    def __init__(self, env, dataset, domain_df, active_attrs, batch_size=32):
+    def __init__(self, env, dataset, domain_df, active_attrs):
         """
         :param dataset: (Dataset) original dataset
         :param domain_df: (DataFrame) currently populated domain dataframe.
@@ -74,6 +72,7 @@ class Logistic(Estimator, torch.nn.Module):
         # and given TID
         self._X = torch.zeros(self.n_samples, self.num_features)
         self._Y = torch.zeros(self.n_samples)
+        self._train_idx = torch.zeros(self.n_samples)  # Keeps track of rows with NULL init_value to ignore in training.
 
         """
         Iterate through the domain for every cell and create a sample
@@ -94,17 +93,22 @@ class Logistic(Estimator, torch.nn.Module):
             assert(feat_tensor.shape[0] == len(domain_vals))
             self._X[sample_idx:sample_idx+len(domain_vals)] = feat_tensor
 
+            # If the init value is not NULL, then we want to use these possible value samples
+            # during training.
+            if rec['init_value'] != NULL_REPR:
+                self._train_idx[sample_idx:sample_idx + len(domain_vals)] = 1
+
             # Assign the tensor corresponding to the initial value with
-            # a target label of 1.
-            try:
+            # a target label of 1. If the initial value is NULL, we do not care because it will be ignored in the training anyways.
+            if rec['init_value'] != NULL_REPR:
                 init_idx = domain_vals.index(rec['init_value'])
                 self._Y[sample_idx + init_idx] = 1
-            except ValueError:
-                logging.error('init value "%s" should be in domain "%s" for VID %d', rec['init_value'], rec['domain'], rec['_vid_'])
-                raise
 
             self.vid_to_idxs[rec['_vid_']] = (sample_idx, sample_idx+len(domain_vals))
             sample_idx += len(domain_vals)
+
+        # Convert this to a vector of indices rather than a vector mask.
+        self._train_idx = (self._train_idx == 1).nonzero()[:,0]
 
         logging.debug('Logistic: DONE featurization in %.2fs', time.clock() - tic)
 
@@ -134,7 +138,8 @@ class Logistic(Estimator, torch.nn.Module):
         :param num_epochs: (int) number of epochs.
         """
         batch_losses = []
-        torch_ds = TensorDataset(self._X, self._Y)
+        X_train, Y_train = self._X.index_select(0, self._train_idx), self._Y.index_select(0, self._train_idx)
+        torch_ds = TensorDataset(X_train, Y_train)
 
         # Main training loop.
         for epoch_idx in range(1, num_epochs+1):
@@ -248,14 +253,19 @@ class CooccurAttrFeaturizer(Featurizer):
                 if attr == other_attr:
                     continue
 
+                other_val = row[other_attr]
+
                 # calculate p(val | other_val)
                 # there may not be co-occurrence frequencies for some value pairs since
                 # our possible values were from correlation with only
                 # one other attribute
-                cooccur = self.cooccur_freq[attr][other_attr][val].get(row[other_attr], 0)
-                freq = self.freq[other_attr][row[other_attr]]
+                if val == NULL_REPR or other_val == NULL_REPR:
+                    fv = NA_COOCCUR_FV
+                else:
+                    cooccur = self.cooccur_freq[attr][other_attr].get(val, {}).get(other_val, NA_COOCCUR_FV)
+                    freq = self.freq[other_attr][row[other_attr]]
+                    fv = float(cooccur) / float(freq)
 
                 feat_idx = self.attr_to_idx[attr] * self.n_attrs + other_attr_idx
-
-                tensor[val_idx,feat_idx] = float(cooccur) / float(freq)
+                tensor[val_idx, feat_idx] = fv
         return tensor

--- a/domain/estimators/logistic.py
+++ b/domain/estimators/logistic.py
@@ -72,7 +72,9 @@ class Logistic(Estimator, torch.nn.Module):
         # and given TID
         self._X = torch.zeros(self.n_samples, self.num_features)
         self._Y = torch.zeros(self.n_samples)
-        self._train_idx = torch.zeros(self.n_samples)  # Keeps track of rows with NULL init_value to ignore in training.
+        # Keeps track of cells with NULL init_value to ignore in training.
+        # We only train on cells when train_idx[idx] == 1.
+        self._train_idx = torch.zeros(self.n_samples)
 
         """
         Iterate through the domain for every cell and create a sample
@@ -179,13 +181,9 @@ class Logistic(Estimator, torch.nn.Module):
         values = self.domain_records[row['_vid_']]['domain'].split('|||')
         return zip(values, map(float, pred_Y))
 
-    def predict_pp_batch(self, raw_records_by_tid=None, cell_domain_rows=None):
+    def predict_pp_batch(self):
         """
         Performs batch prediction.
-
-        Parameters are ignored: instead it returns the predictions for cells
-        and domain values ordered by VID of the initial domain dataframe
-        passed into the constructor.
         """
         pred_Y = self.forward(self._X)
         for rec in self.domain_records:

--- a/domain/estimators/naive_bayes.py
+++ b/domain/estimators/naive_bayes.py
@@ -3,6 +3,7 @@ import math
 from tqdm import tqdm
 
 from ..estimator import Estimator
+from utils import NULL_REPR
 
 
 class NaiveBayes(Estimator):
@@ -41,6 +42,12 @@ class NaiveBayes(Estimator):
                 if at == attr or at == '_tid_':
                     continue
                 val2 = row[at]
+                # Since we do not have co-occurrence stats with NULL values,
+                # we skip them.
+                # It also doesn't make sense for our likelihood to be conditioned
+                # on a NULL value.
+                # if val2 == NULL_REPR:
+                #     continue
                 val2_val1_count = 0.1
                 if val1 in self._cooccur_freq[attr][at]:
                     if val2 in self._cooccur_freq[attr][at][val1]:

--- a/domain/estimators/naive_bayes.py
+++ b/domain/estimators/naive_bayes.py
@@ -46,8 +46,8 @@ class NaiveBayes(Estimator):
                 # we skip them.
                 # It also doesn't make sense for our likelihood to be conditioned
                 # on a NULL value.
-                # if val2 == NULL_REPR:
-                #     continue
+                if val2 == NULL_REPR:
+                    continue
                 val2_val1_count = 0.1
                 if val1 in self._cooccur_freq[attr][at]:
                     if val2 in self._cooccur_freq[attr][at][val1]:

--- a/evaluate/eval.py
+++ b/evaluate/eval.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from dataset import AuxTables
 from dataset.table import Table, Source
+from utils import NULL_REPR
 
 EvalReport = namedtuple('EvalReport', ['precision', 'recall', 'repair_recall',
     'f1', 'repair_f1', 'detected_errors', 'total_errors', 'correct_repairs',
@@ -50,7 +51,7 @@ class EvalEngine:
         tic = time.clock()
         try:
             raw_data = pd.read_csv(fpath, na_values=na_values, encoding='utf-8')
-            raw_data.fillna('_nan_', inplace=True)
+            raw_data.fillna(NULL_REPR, inplace=True)
             raw_data.rename({tid_col: '_tid_',
                              attr_col: '_attribute_',
                              val_col: '_value_'},

--- a/evaluate/eval.py
+++ b/evaluate/eval.py
@@ -51,7 +51,6 @@ class EvalEngine:
         tic = time.clock()
         try:
             raw_data = pd.read_csv(fpath, na_values=na_values, encoding='utf-8')
-            import pdb; pdb.set_trace()
             # We drop any ground truth values that are NULLs since we follow
             # the closed-world assumption (if it's not there it's wrong).
             # TODO: revisit this once we allow users to specify which

--- a/evaluate/eval.py
+++ b/evaluate/eval.py
@@ -51,6 +51,12 @@ class EvalEngine:
         tic = time.clock()
         try:
             raw_data = pd.read_csv(fpath, na_values=na_values, encoding='utf-8')
+            import pdb; pdb.set_trace()
+            # We drop any ground truth values that are NULLs since we follow
+            # the closed-world assumption (if it's not there it's wrong).
+            # TODO: revisit this once we allow users to specify which
+            # attributes may be NULL.
+            raw_data.dropna(subset=[val_col], inplace=True)
             raw_data.fillna(NULL_REPR, inplace=True)
             raw_data.rename({tid_col: '_tid_',
                              attr_col: '_attribute_',

--- a/examples/holoclean_repair_example.py
+++ b/examples/holoclean_repair_example.py
@@ -31,21 +31,20 @@ hc.load_data('hospital', '../testdata/hospital.csv')
 hc.load_dcs('../testdata/hospital_constraints.txt')
 hc.ds.set_constraints(hc.get_dcs())
 
-# 3. Detect erroneous cells using these two detectors.
-detectors = [NullDetector(), ViolationDetector()]
-hc.detect_errors(detectors)
-
-# 4. Repair errors utilizing the defined features.
-hc.setup_domain()
-featurizers = [
-    InitAttrFeaturizer(),
-    OccurAttrFeaturizer(),
-    FreqFeaturizer(),
-    ConstraintFeaturizer(),
-    LangModelFeaturizer(),
-]
-
-hc.repair_errors(featurizers)
+# # 3. Detect erroneous cells using these two detectors.
+# detectors = [NullDetector(), ViolationDetector()]
+# hc.detect_errors(detectors)
+#
+# # 4. Repair errors utilizing the defined features.
+# hc.setup_domain()
+# featurizers = [
+#     InitAttrFeaturizer(),
+#     OccurAttrFeaturizer(),
+#     FreqFeaturizer(),
+#     ConstraintFeaturizer(),
+# ]
+#
+# hc.repair_errors(featurizers)
 
 # 5. Evaluate the correctness of the results.
 hc.evaluate(fpath='../testdata/hospital_clean.csv',

--- a/examples/holoclean_repair_example.py
+++ b/examples/holoclean_repair_example.py
@@ -31,20 +31,20 @@ hc.load_data('hospital', '../testdata/hospital.csv')
 hc.load_dcs('../testdata/hospital_constraints.txt')
 hc.ds.set_constraints(hc.get_dcs())
 
-# # 3. Detect erroneous cells using these two detectors.
-# detectors = [NullDetector(), ViolationDetector()]
-# hc.detect_errors(detectors)
-#
-# # 4. Repair errors utilizing the defined features.
-# hc.setup_domain()
-# featurizers = [
-#     InitAttrFeaturizer(),
-#     OccurAttrFeaturizer(),
-#     FreqFeaturizer(),
-#     ConstraintFeaturizer(),
-# ]
-#
-# hc.repair_errors(featurizers)
+# 3. Detect erroneous cells using these two detectors.
+detectors = [NullDetector(), ViolationDetector()]
+hc.detect_errors(detectors)
+
+# 4. Repair errors utilizing the defined features.
+hc.setup_domain()
+featurizers = [
+    InitAttrFeaturizer(),
+    OccurAttrFeaturizer(),
+    FreqFeaturizer(),
+    ConstraintFeaturizer(),
+]
+
+hc.repair_errors(featurizers)
 
 # 5. Evaluate the correctness of the results.
 hc.evaluate(fpath='../testdata/hospital_clean.csv',

--- a/repair/featurize/featurized_dataset.py
+++ b/repair/featurize/featurized_dataset.py
@@ -8,6 +8,7 @@ import torch
 import torch.nn.functional as F
 
 from dataset import AuxTables, CellStatus
+from utils import NULL_REPR
 
 FeatInfo = namedtuple('FeatInfo', ['name', 'size', 'learnable', 'init_weight', 'feature_names'])
 
@@ -65,13 +66,17 @@ class FeaturizedDataset:
             contains the domain index of the initial value for the i-th
             variable/VID.
         """
-        # Trains with clean cells AND cells that have been weak labelled.
-        query = 'SELECT _vid_, weak_label_idx, fixed, (t2._cid_ IS NULL) AS clean ' \
-                'FROM {} AS t1 LEFT JOIN {} AS t2 ON t1._cid_ = t2._cid_ ' \
-                'WHERE t2._cid_ is NULL ' \
-                '   OR t1.fixed != {};'.format(AuxTables.cell_domain.name,
-                                               AuxTables.dk_cells.name,
-                                               CellStatus.NOT_SET.value)
+        # Generate weak labels for clean cells AND cells that have been weak
+        # labelled. Do not train on cells with NULL weak labels (i.e.
+        # NULL init values that were not weak labelled).
+        query = """
+        SELECT _vid_, weak_label_idx, fixed, (t2._cid_ IS NULL) AS clean
+        FROM {cell_domain} AS t1 LEFT JOIN {dk_cells} AS t2 ON t1._cid_ = t2._cid_
+        WHERE weak_label != '{null_repr}' AND (t2._cid_ is NULL OR t1.fixed != {cell_status});
+        """.format(cell_domain=AuxTables.cell_domain.name,
+                dk_cells=AuxTables.dk_cells.name,
+                null_repr=NULL_REPR,
+                cell_status=CellStatus.NOT_SET.value)
         res = self.ds.engine.execute_query(query)
         if len(res) == 0:
             raise Exception("No weak labels available. Reduce pruning threshold.")

--- a/repair/featurize/occurattrfeat.py
+++ b/repair/featurize/occurattrfeat.py
@@ -6,13 +6,14 @@ from tqdm import tqdm
 
 from .featurizer import Featurizer
 from dataset import AuxTables
+from utils import NULL_REPR, NA_COOCCUR_FV
 
 
 class OccurAttrFeaturizer(Featurizer):
     def specific_setup(self):
         self.name = 'OccurAttrFeaturizer'
         if not self.setup_done:
-            raise Exception('Featurizer %s is not properly setup.'%self.name)
+            raise Exception('Featurizer {} is not properly setup.'.format(self.name))
         self.all_attrs = self.ds.get_attributes()
         self.attrs_number = len(self.ds.attr_to_idx)
         self.raw_data_dict = {}
@@ -33,7 +34,7 @@ class OccurAttrFeaturizer(Featurizer):
         tensors = []
         # Set tuple_id index on raw_data
         t = self.ds.aux_table[AuxTables.cell_domain]
-        sorted_domain = t.df.reset_index().sort_values(by=['_vid_'])[['_tid_','attribute','_vid_','domain']]
+        sorted_domain = t.df.reset_index().sort_values(by=['_vid_'])[['_tid_', 'attribute', '_vid_', 'domain']]
         records = sorted_domain.to_records()
         for row in tqdm(list(records)):
             # Get tuple from raw_dataset.
@@ -45,33 +46,30 @@ class OccurAttrFeaturizer(Featurizer):
         return combined
 
     def gen_feat_tensor(self, row, tuple):
-        tensor = torch.zeros(1, self.classes, self.attrs_number*self.attrs_number)
+        tensor = torch.zeros(1, self.classes, self.attrs_number * self.attrs_number)
         rv_attr = row['attribute']
         domain = row['domain'].split('|||')
         rv_domain_idx = {val: idx for idx, val in enumerate(domain)}
         rv_attr_idx = self.ds.attr_to_idx[rv_attr]
         for attr in self.all_attrs:
-            if attr != rv_attr and (not pd.isnull(tuple[attr])):
-                attr_idx = self.ds.attr_to_idx[attr]
-                val = tuple[attr]
-                count1 = float(self.single_stats[attr][val])
-                # Get topK values
-                if val not in self.pair_stats[attr][rv_attr]:
-                    if not pd.isnull(tuple[rv_attr]):
-                        logging.error('Cannot find attribute: %s with value %s in pair-wise statistics' % (attr, val))
-                        raise Exception('Something is wrong with the pairwise statistics. <Val> should be present in dictionary.')
-                else:
-                    all_vals = self.pair_stats[attr][rv_attr][val]
-                    if len(all_vals) <= len(rv_domain_idx):
-                        candidates = all_vals
-                    else:
-                        candidates = domain
-                    for rv_val in candidates:
-                        count2 = float(all_vals.get(rv_val,0.0))
-                        prob = count2/count1
-                        if rv_val in rv_domain_idx:
-                            index = rv_attr_idx * self.attrs_number + attr_idx
-                            tensor[0][rv_domain_idx[rv_val]][index] = prob
+            val = tuple[attr]
+
+            # Ignore co-occurrences of same attribute or with null values.
+            if attr == rv_attr \
+                    or pd.isnull(val) \
+                    or val == NULL_REPR \
+                    or val not in self.single_stats[attr] \
+                    or val not in self.pair_stats[attr][rv_attr]:
+                continue
+            attr_idx = self.ds.attr_to_idx[attr]
+            count1 = float(self.single_stats[attr][val])
+            all_vals = self.pair_stats[attr][rv_attr][val]
+            for rv_val in domain:
+                count2 = float(all_vals.get(rv_val, 0.0))
+                prob = count2 / count1
+                if rv_val in rv_domain_idx:
+                    index = rv_attr_idx * self.attrs_number + attr_idx
+                    tensor[0][rv_domain_idx[rv_val]][index] = prob
         return tensor
 
     def feature_names(self):

--- a/repair/featurize/occurattrfeat.py
+++ b/repair/featurize/occurattrfeat.py
@@ -50,15 +50,17 @@ class OccurAttrFeaturizer(Featurizer):
         rv_attr = row['attribute']
         domain = row['domain'].split('|||')
         rv_domain_idx = {val: idx for idx, val in enumerate(domain)}
+        # We should not have any NULLs in our domain.
+        assert NULL_REPR not in rv_domain_idx
         rv_attr_idx = self.ds.attr_to_idx[rv_attr]
         for attr in self.all_attrs:
             val = tuple[attr]
 
             # Ignore co-occurrences of same attribute or with null values.
+            # It's possible a value is not in pair_stats if it only co-occurred
+            # with NULL values.
             if attr == rv_attr \
-                    or pd.isnull(val) \
                     or val == NULL_REPR \
-                    or val not in self.single_stats[attr] \
                     or val not in self.pair_stats[attr][rv_attr]:
                 continue
             attr_idx = self.ds.attr_to_idx[attr]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numpy==1.16.1
 pandas==0.24.1
 psycopg2-binary==2.7.7
 pyitlib==0.2.0
-pytest==4.2.0
+pytest-xdist==1.26.1
 python-Levenshtein==0.12.0
 scikit-learn==0.20.0
 scipy==1.2.1

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+from .testutils import random_database, delete_database
+
+__all__ = ['random_database', 'delete_database']

--- a/tests/start_test.sh
+++ b/tests/start_test.sh
@@ -5,4 +5,4 @@ source ../set_env.sh
 
 # Launch tests.
 echo "Launching tests..."
-pytest
+pytest -n 4

--- a/tests/start_test.sh
+++ b/tests/start_test.sh
@@ -5,4 +5,4 @@ source ../set_env.sh
 
 # Launch tests.
 echo "Launching tests..."
-pytest -n 4
+pytest -n 1

--- a/tests/test_holoclean_repair.py
+++ b/tests/test_holoclean_repair.py
@@ -132,6 +132,6 @@ def test_hospital_without_init():
         assert abs(report.precision - 434. / 456) < TOL
         assert abs(report.recall - 434. / 509) < TOL
         assert abs(report.repair_recall - 434. / 435) < TOL
-        assert report.total_repairs_grdt_correct == 0
+        assert report.total_repairs_grdt_correct == 22
     finally:
         delete_database(db_name)

--- a/tests/test_holoclean_repair.py
+++ b/tests/test_holoclean_repair.py
@@ -2,63 +2,136 @@ from detect import NullDetector, ViolationDetector
 import holoclean
 from repair.featurize import *
 
+from tests.testutils import random_database, delete_database
+
 TOL = 1e-9
 
 
-def test_hospital():
-    # 1. Setup a HoloClean session.
-    hc = holoclean.HoloClean(
-        db_name='holo',
-        domain_thresh_1=0.0,
-        domain_thresh_2=0.0,
-        weak_label_thresh=0.99,
-        max_domain=10000,
-        cor_strength=0.6,
-        nb_cor_strength=0.8,
-        epochs=10,
-        weight_decay=0.01,
-        learning_rate=0.001,
-        threads=1,
-        batch_size=1,
-        verbose=True,
-        timeout=3 * 60000,
-        feature_norm=False,
-        weight_norm=False,
-        print_fw=True
-    ).session
+def test_hospital_with_init():
+    db_name = random_database()
 
-    # 2. Load training data and denial constraints.
-    hc.load_data('hospital', '../testdata/hospital.csv')
-    hc.load_dcs('../testdata/hospital_constraints.txt')
-    hc.ds.set_constraints(hc.get_dcs())
+    try:
+        # 1. Setup a HoloClean session.
+        hc = holoclean.HoloClean(
+            db_name=db_name,
+            domain_thresh_1=0.0,
+            domain_thresh_2=0.0,
+            weak_label_thresh=0.99,
+            max_domain=10000,
+            cor_strength=0.6,
+            nb_cor_strength=0.8,
+            epochs=10,
+            weight_decay=0.01,
+            learning_rate=0.001,
+            threads=1,
+            batch_size=1,
+            verbose=True,
+            timeout=3 * 60000,
+            feature_norm=False,
+            weight_norm=False,
+            print_fw=True
+        ).session
 
-    # 3. Detect erroneous cells using these two detectors.
-    detectors = [NullDetector(), ViolationDetector()]
-    hc.detect_errors(detectors)
+        # 2. Load training data and denial constraints.
+        hc.load_data('hospital', '../testdata/hospital.csv')
+        hc.load_dcs('../testdata/hospital_constraints.txt')
+        hc.ds.set_constraints(hc.get_dcs())
 
-    # 4. Repair errors utilizing the defined features.
-    hc.setup_domain()
-    featurizers = [
-        InitAttrFeaturizer(),
-        OccurAttrFeaturizer(),
-        FreqFeaturizer(),
-        ConstraintFeaturizer(),
-        LangModelFeaturizer(),
-    ]
+        # 3. Detect erroneous cells using these two detectors.
+        detectors = [NullDetector(), ViolationDetector()]
+        hc.detect_errors(detectors)
 
-    hc.repair_errors(featurizers)
+        # 4. Repair errors utilizing the defined features.
+        hc.setup_domain()
+        featurizers = [
+            InitAttrFeaturizer(),
+            OccurAttrFeaturizer(),
+            FreqFeaturizer(),
+            ConstraintFeaturizer(),
+            LangModelFeaturizer(),
+        ]
 
-    # 5. Evaluate the correctness of the results.
-    report = hc.evaluate(fpath='../testdata/hospital_clean.csv',
-                tid_col='tid',
-                attr_col='attribute',
-                val_col='correct_val')
+        hc.repair_errors(featurizers)
 
-    # We assert that our key metrics are exactly as tested for hospital.
-    # If these assertions ever fail in a new change, the results should
-    # be comparable if not better than before, unless a clear and correct
-    # reason can be given.
-    assert abs(report.precision - 1.) < TOL
-    assert abs(report.recall - 231. / 509) < TOL
-    assert abs(report.repair_recall - 231. / 435) < TOL
-    assert report.total_repairs_grdt_correct == 0
+        # 5. Evaluate the correctness of the results.
+        report = hc.evaluate(fpath='../testdata/hospital_clean.csv',
+                    tid_col='tid',
+                    attr_col='attribute',
+                    val_col='correct_val')
+
+        # We assert that our key metrics are exactly as tested for hospital.
+        # If these assertions ever fail in a new change, the results should
+        # be comparable if not better than before, unless a clear and correct
+        # reason can be given.
+        assert report.correct_repairs == 232
+        assert report.total_repairs == 232
+        assert abs(report.precision - 1.) < TOL
+        assert abs(report.recall - 232. / 509) < TOL
+        assert abs(report.repair_recall - 232. / 435) < TOL
+        assert report.total_repairs_grdt_correct == 0
+    finally:
+        delete_database(db_name)
+
+def test_hospital_without_init():
+    db_name = random_database()
+
+    try:
+        # 1. Setup a HoloClean session.
+        hc = holoclean.HoloClean(
+            db_name='holo',
+            domain_thresh_1=0.0,
+            domain_thresh_2=0.0,
+            weak_label_thresh=0.99,
+            max_domain=10000,
+            cor_strength=0.6,
+            nb_cor_strength=0.8,
+            epochs=10,
+            weight_decay=0.01,
+            learning_rate=0.001,
+            threads=1,
+            batch_size=1,
+            verbose=True,
+            timeout=3 * 60000,
+            feature_norm=False,
+            weight_norm=False,
+            print_fw=True
+        ).session
+
+        # 2. Load training data and denial constraints.
+        hc.load_data('hospital', '../testdata/hospital.csv')
+        hc.load_dcs('../testdata/hospital_constraints.txt')
+        hc.ds.set_constraints(hc.get_dcs())
+
+        # 3. Detect erroneous cells using these two detectors.
+        detectors = [NullDetector(), ViolationDetector()]
+        hc.detect_errors(detectors)
+
+        # 4. Repair errors utilizing the defined features.
+        hc.setup_domain()
+        featurizers = [
+            OccurAttrFeaturizer(),
+            FreqFeaturizer(),
+            ConstraintFeaturizer(),
+            LangModelFeaturizer(),
+        ]
+
+        hc.repair_errors(featurizers)
+
+        # 5. Evaluate the correctness of the results.
+        report = hc.evaluate(fpath='../testdata/hospital_clean.csv',
+                    tid_col='tid',
+                    attr_col='attribute',
+                    val_col='correct_val')
+
+        # We assert that our key metrics are exactly as tested for hospital.
+        # If these assertions ever fail in a new change, the results should
+        # be comparable if not better than before, unless a clear and correct
+        # reason can be given.
+        assert report.correct_repairs == 434
+        assert report.total_repairs == 456
+        assert abs(report.precision - 434. / 456) < TOL
+        assert abs(report.recall - 434. / 509) < TOL
+        assert abs(report.repair_recall - 434. / 435) < TOL
+        assert report.total_repairs_grdt_correct == 0
+    finally:
+        delete_database(db_name)

--- a/tests/test_holoclean_repair.py
+++ b/tests/test_holoclean_repair.py
@@ -48,7 +48,6 @@ def test_hospital_with_init():
             OccurAttrFeaturizer(),
             FreqFeaturizer(),
             ConstraintFeaturizer(),
-            LangModelFeaturizer(),
         ]
 
         hc.repair_errors(featurizers)
@@ -112,7 +111,6 @@ def test_hospital_without_init():
             OccurAttrFeaturizer(),
             FreqFeaturizer(),
             ConstraintFeaturizer(),
-            LangModelFeaturizer(),
         ]
 
         hc.repair_errors(featurizers)

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -1,0 +1,41 @@
+import random
+
+from psycopg2 import connect
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+
+
+def random_database():
+    """
+    Creates a random database in the testing Postgres instance and returns the
+    name of the database.
+    """
+    # Setup connection with default credentials for testing.
+    with connect(dbname='holo', user='holocleanuser', password='abcd1234', host='localhost') as conn:
+        conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+        with conn.cursor() as cur:
+            while True:
+                # Generate a random DB name that is not already in Postgres.
+                db_name = 'test_holo_{}'.format(random.randint(0, 1e6))
+                cur.execute("""
+                    SELECT EXISTS(
+                        SELECT datname FROM pg_catalog.pg_database
+                        WHERE datname = '{db_name}'
+                    );
+                """.format(db_name=db_name))
+                if cur.fetchall()[0][0]:
+                    continue
+
+                cur.execute("CREATE DATABASE {db_name}".format(db_name=db_name))
+                return db_name
+
+def delete_database(db_name):
+    with connect(dbname='holo', user='holocleanuser', password='abcd1234', host='localhost') as conn:
+        conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+        with conn.cursor() as cur:
+            # Terminate un-closed connections.
+            cur.execute("""
+            SELECT pid, pg_terminate_backend(pid)
+            FROM pg_stat_activity
+            WHERE datname = current_database() AND pid <> pg_backend_pid();""")
+            # Drop the database.
+            cur.execute("DROP DATABASE IF EXISTS {db_name}".format(db_name=db_name))

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -36,6 +36,6 @@ def delete_database(db_name):
             cur.execute("""
             SELECT pid, pg_terminate_backend(pid)
             FROM pg_stat_activity
-            WHERE datname = current_database() AND pid <> pg_backend_pid();""")
+            WHERE datname = '{db_name}' AND pid <> pg_backend_pid();""".format(db_name=db_name))
             # Drop the database.
             cur.execute("DROP DATABASE IF EXISTS {db_name}".format(db_name=db_name))

--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,12 @@
+# Some constants.
+
+# How we represent nulls in holoclean.
+NULL_REPR = '_nan_'
+
+# A feature value to represent co-occurrence with NULLs, which is not applicable.
+NA_COOCCUR_FV = 0
+
+
 def dictify_df(frame):
     """
     dictify_df converts a frame with columns


### PR DESCRIPTION
We remove NULLs from the domain. Therefore if a cell is initially NULL we always predict a non-NULL value _unless_ we cannot generate a non-trivial domain based on co-occurring values from correlated attributes.

We maintain our previous precision and recall as desired (with settings in `holoclean_repair_example.py`)
```
23:01:27 - [ INFO] - Precision = 1.00, Recall = 0.46, Repairing Recall = 0.53, F1 = 0.63, Repairing F1 = 0.70, Detected Errors = 435, Total Errors = 509, Correct Repairs = 232, Total Repairs = 459, Total Repairs on correct cells (Grdth present) = 0, Total Repairs on incorrect cells (Grdth present) = 232
```

Same settings as above but without `InitAttrFeaturizer`:
```
23:12:57 - [ INFO] - Precision = 0.95, Recall = 0.85, Repairing Recall = 1.00, F1 = 0.90, Repairing F1 = 0.97, Detected Errors = 435, Total Errors = 509, Correct Repairs = 434, Total Repairs = 683, Total Repairs on correct cells (Grdth present) = 22, Total Repairs on incorrect cells (Grdth present) = 434
```