### PR TITLE
fix bugs on ConstraintFeaturizer

### DIFF
--- a/dcparser/constraint.py
+++ b/dcparser/constraint.py
@@ -10,6 +10,19 @@ def is_symmetric(operation):
     return False
 
 
+def get_flip_operation(operation):
+    if operation == '<=':
+        return '>='
+    elif operation == '>=':
+        return '<='
+    elif operation == '<':
+        return '>'
+    elif operation == '>':
+        return '<'
+    else:
+        return operation
+
+
 def contains_operation(string):
     """
     Method to check if a given string contains one of the operation signs.

--- a/repair/featurize/constraintfeat.py
+++ b/repair/featurize/constraintfeat.py
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 
 from .featurizer import Featurizer
 from dataset import AuxTables
-from dcparser.constraint import is_symmetric
+from dcparser.constraint import is_symmetric, get_flip_operation
 
 # unary_template is used for constraints where the current predicate
 # used for detecting violations in pos_values have a reference to only
@@ -111,6 +111,10 @@ class ConstraintFeaturizer(Featurizer):
         """
         attr = predicate.components[rel_idx][1]
         op = predicate.operation
+        # the latter one should flip the operation,
+        # if t3.rv_val is always on the left side in query template
+        if rel_idx == 1:
+            op = get_flip_operation(op)
         const = '{}."{}"'.format(
                 predicate.components[1-rel_idx][0],
                 predicate.components[1-rel_idx][1])


### PR DESCRIPTION
When generating relaxed sql, the operation should be flipped to
keep the sql right when non-symmetric operation is used in DC.