### PR TITLE
do not drop cells whose init are null with dom(len) <= 1

### DIFF
--- a/domain/domain.py
+++ b/domain/domain.py
@@ -210,8 +210,8 @@ class DomainEngine:
                     # a domain (note that NULL is not included in the domain);
                     # a random domain probably won't help us so
                     # completely ignore this cell and continue.
-                    if init_value == NULL_REPR:
-                        continue
+                    # if init_value == NULL_REPR:
+                    #    continue
 
                     # Not enough domain values, we need to get some random
                     # values (other than 'init_value') for training. However,

--- a/domain/estimators/tuple_embedding.py
+++ b/domain/estimators/tuple_embedding.py
@@ -1202,7 +1202,10 @@ class TupleEmbedding(Estimator, torch.nn.Module):
                         domain_idxs,
                         domain_masks)
 
-                cat_probas = Softmax(dim=1)(cat_logits)
+                if cat_logits.nelement():
+                    cat_probas = Softmax(dim=1)(cat_logits)
+                else:
+                    cat_probas = cat_logits
 
                 # (# of cats), (# of num)
                 cat_masks, num_masks = self._cat_num_masks(is_categorical)


### PR DESCRIPTION
1. Comment on domain.py to not drop cells whose init are null (especially for the HospitalType attribute which has only one value in the domain)
2. Change codes in tuple_embedding.py to avoid `float exception` in some of the ubuntu serves (e.g., husky-04 and husky-09)