### PR TITLE
fix err: cast value to string before .str

### DIFF
--- a/evaluate/eval.py
+++ b/evaluate/eval.py
@@ -64,7 +64,7 @@ class EvalEngine:
                             inplace=True)
             raw_data = raw_data[['_tid_', '_attribute_', '_value_']]
             # Normalize string to whitespaces.
-            raw_data['_value_'] = raw_data['_value_'].str.strip().str.lower()
+            raw_data['_value_'] = raw_data['_value_'].astype(str).str.strip().str.lower()
             self.clean_data = Table(name, Source.DF, df=raw_data)
             self.clean_data.store_to_db(self.ds.engine.engine)
             self.clean_data.create_db_index(self.ds.engine, ['_tid_'])


### PR DESCRIPTION
in eval.py line 67: need to cast raw_data['_value_'] into string before '.str', if raw_data['_value_'] is not string value, it will cause error:  'AttributeError: Can only use .str accessor with string values, which use np.object_ dtype in pandas'